### PR TITLE
build: fix install path for dbus service

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,11 +1,12 @@
 conf_data = configuration_data()
-conf_data.set('EXEC_PATH', join_paths (get_option('prefix'), get_option('bindir'), meson.project_name()))
+conf_data.set('EXEC_PATH', join_paths (bindir, meson.project_name()))
 
 dbus = dependency('dbus-1')
+session_bus_services_dir = dbus.get_pkgconfig_variable('session_bus_services_dir', define_variable: ['datadir', datadir])
 
 configure_file(
     input: 'org.elementary.contractor.service.in',
     output: '@BASENAME@',
     configuration: conf_data,
-    install_dir: dbus.get_pkgconfig_variable('session_bus_services_dir')
+    install_dir: session_bus_services_dir
 )

--- a/meson.build
+++ b/meson.build
@@ -7,5 +7,9 @@ project(
 i18n = import('i18n')
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()), language:'c')
 
+prefix = get_option('prefix')
+datadir = join_paths(prefix, get_option('datadir'))
+bindir = join_paths(prefix, get_option('bindir'))
+
 subdir('src')
 subdir('data')


### PR DESCRIPTION
On NixOS all packages are installed into their own immutable prefix.
Because of this dbus.get_pkgconfig_variable will return a
path from within dbus's prefix and we cannot write to it.
By using define_variable we can replace the datadir to
be from the paths from meson. This should have no affect
on elementaryOS.