### PR TITLE
Release 0.3.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+contractor (0.3.5) focal; urgency=medium
+
+  * Fix install path for DBus service
+
+ -- Daniel Foré <daniel@elementary.io>  Tue, 13 Jul 2021 14:33:42 -0700
+
 contractor (0.3.4) bionic; urgency=medium
 
   * New upstream release.

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: contractor
 Section: utils
 Priority: optional
-Maintainer: Cody Garver <cody@elementary.io>
+Maintainer: elementary, Inc. <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
                libdbus-1-dev,
                libgee-0.8-dev,


### PR DESCRIPTION
There's no release action here. We will need to manually tag a GitHub release after merging

LP recipe needs to be created also