### PR TITLE
Install into libexecdir instead of bindir

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,5 +1,5 @@
 conf_data = configuration_data()
-conf_data.set('EXEC_PATH', join_paths (bindir, meson.project_name()))
+conf_data.set('EXEC_PATH', join_paths (libexecdir, meson.project_name()))
 
 dbus = dependency('dbus-1')
 session_bus_services_dir = dbus.get_pkgconfig_variable('session_bus_services_dir', define_variable: ['datadir', datadir])

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()), lan
 
 prefix = get_option('prefix')
 datadir = join_paths(prefix, get_option('datadir'))
-bindir = join_paths(prefix, get_option('bindir'))
+libexecdir = join_paths(prefix, get_option('libexecdir'))
 
 subdir('src')
 subdir('data')

--- a/src/meson.build
+++ b/src/meson.build
@@ -30,5 +30,6 @@ executable(
     meson.project_name(),
     files,
     dependencies: dependencies,
-    install : true
+    install : true,
+    install_dir : libexecdir
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -30,6 +30,6 @@ executable(
     meson.project_name(),
     files,
     dependencies: dependencies,
-    install : true,
-    install_dir : libexecdir
+    install: true,
+    install_dir: libexecdir
 )


### PR DESCRIPTION
As far as I can tell (and I may well be missing something!), `contractor` is only executed via the service file, and nothing really needs it to be on the system `PATH`. So… what if it’s installed in [`libexecdir` instead of `bindir`](https://mesonbuild.com/Builtin-options.html#directories), i.e. `/usr/libexec` instead of `/usr/bin` on a typical `/usr`-prefix installation?