### PR TITLE
Rename RDNN to io.elementary.contractor

### DIFF
--- a/data/io.elementary.contractor.service.in
+++ b/data/io.elementary.contractor.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
-Name=org.elementary.Contractor
+Name=io.elementary.Contractor
 Exec=@EXEC_PATH@

--- a/data/meson.build
+++ b/data/meson.build
@@ -5,7 +5,7 @@ dbus = dependency('dbus-1')
 session_bus_services_dir = dbus.get_pkgconfig_variable('session_bus_services_dir', define_variable: ['datadir', datadir])
 
 configure_file(
-    input: 'org.elementary.contractor.service.in',
+    input: 'io.elementary.contractor.service.in',
     output: '@BASENAME@',
     configuration: conf_data,
     install_dir: session_bus_services_dir

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -16,8 +16,8 @@
  */
 
 public class Contractor.Application {
-    private const string DBUS_NAME = "org.elementary.Contractor";
-    private const string DBUS_PATH = "/org/elementary/contractor";
+    private const string DBUS_NAME = "io.elementary.Contractor";
+    private const string DBUS_PATH = "/io/elementary/contractor";
 
     private DBusService dbus_service;
     private MainLoop main_loop;

--- a/src/DBusService.vala
+++ b/src/DBusService.vala
@@ -23,7 +23,7 @@
  */
 
 namespace Contractor {
-    [DBus (name = "org.elementary.ContractorError")]
+    [DBus (name = "io.elementary.ContractorError")]
     /**
      * Errors specific to the Contractor D-Bus service.
      */
@@ -38,7 +38,7 @@ namespace Contractor {
      * A D-Bus service handling requests for Contracts defined by .contract
      * files.
      */
-    [DBus (name = "org.elementary.Contractor")]
+    [DBus (name = "io.elementary.Contractor")]
     public class DBusService : Object {
         /**
          * Signal which gets sent when Contracts change.


### PR DESCRIPTION
Fixes #30

Changed the name of the service description file (`data/org.elementary.contractor.service` is now called `data/io.elementary.contractor.service`), and also changed references to this service in some files in the `src/` folder